### PR TITLE
Replace social media bttns

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -32,10 +32,6 @@
         </li>
         {% endif %}
 
-        <li class="nav-item">
-          <a class="nav-link" href="mailto:{{ site.email }}?subject=Join%20{{ site.title | escape }}"><i class="material-icons">mail_outline</i></a>
-        </li>
-
         {% if site.email %}
         <li class="nav-item">
           {% include icon-mail.html username=site.email %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -35,6 +35,13 @@
         <li class="nav-item">
           <a class="nav-link" href="mailto:{{ site.email }}?subject=Join%20{{ site.title | escape }}"><i class="material-icons">mail_outline</i></a>
         </li>
+
+        {% if site.email %}
+        <li class="nav-item">
+          {% include icon-mail.html username=site.email %}
+        </li>
+        {% endif %}
+
     </ul>
 
     <div class="spacer clearfix"></div>

--- a/_includes/icon-mail.html
+++ b/_includes/icon-mail.html
@@ -1,0 +1,1 @@
+<a href="mailto:{{ site.email }}?subject=Join%20{{ site.title | escape }}" class="nav-link"><span class="icon icon-mail">{% include icon-mail.svg %}</span></a>

--- a/_includes/icon-mail.svg
+++ b/_includes/icon-mail.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generate more at customizr.net -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg id="mail" class="custom-icon" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100" style="height: 36px; width: 36px;"><rect class="outer-shape" x="0" y="0" width="100" height="100" rx="20" ry="20" style="opacity: 1; fill: rgb(255, 255, 255);"></rect>
+	<path class="inner-shape" style="opacity: 1; fill: rgb(36, 46, 99);" transform="translate(25,25) scale(0.5)" d="M50,1C22.938,1,1,22.938,1,50s21.938,49,49,49s49-21.938,49-49S77.062,1,50,1z M25.5,25.5h49 c0.874,0,1.723,0.188,2.502,0.542L50,57.544L22.998,26.041C23.777,25.687,24.626,25.499,25.5,25.5L25.5,25.5z M19.375,68.375v-36.75 c0-0.128,0.005-0.256,0.014-0.383l17.96,20.953L19.587,69.958C19.448,69.447,19.376,68.916,19.375,68.375L19.375,68.375z M74.5,74.5 h-49c-0.541,0-1.072-0.073-1.583-0.212l17.429-17.429L50,66.956l8.653-10.096l17.429,17.429C75.572,74.427,75.041,74.5,74.5,74.5 L74.5,74.5z M80.625,68.375c0,0.541-0.073,1.072-0.211,1.583L62.652,52.195l17.96-20.953c0.008,0.127,0.014,0.255,0.014,0.383 L80.625,68.375L80.625,68.375z"></path>
+</svg>


### PR DESCRIPTION
Replace the old social media buttons in the footer with a new style button.
Add buttons for youtube and soundcloud.
Replace the bootstrap format email button with the new svg button.